### PR TITLE
perf: DAF-7 - Changes pickle to cPickle for inc. speed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def listify(filename):
 
 setup(
     name = "django-dirtyfields",
-    version = "0.2.3",
+    version = "0.2.4",
     url = 'http://github.com/smn/django-dirtyfields',
     license = 'BSD',
     description = "Tracking dirty fields on a Django model instance",

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -2,7 +2,10 @@
 from django.db.models.signals import post_save, pre_save
 try:
     from picklefield import PickledObjectField
-    import pickle
+    try:
+        import cPickle as pickle
+    except ImportError:
+        import pickle
     pickled_object_field_loaded = True
 except ImportError:
     pickled_object_field_loaded = False


### PR DESCRIPTION
This PR will intentionally clobber the existing 0.2.4 we already merged. The previously attempted `copy` approach causes problems with the monolith, it turns out.